### PR TITLE
Use Goroutine when Update the DB

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queu
 		go func() {
 			err := eq.MarkEventAsProcessed(event.ID)
 			if err != nil {
-				logrus.Fatalf("Error marking record as processed %v", err)
+				logrus.Infof("Error marking record as processed %v", err)
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -129,7 +129,6 @@ func waitForNotification(
 }
 
 func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queue) {
-	start := time.Now()
 	deliveryChan := make(chan kafka.Event)
 	for _, event := range events {
 		msg, err := json.Marshal(event)
@@ -172,8 +171,6 @@ func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queu
 			}
 		}()
 	}
-	elapsed := time.Since(start)
-	fmt.Printf("productMessage / 1000 took %s", elapsed)
 }
 
 func setupProducer() Producer {

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func waitForNotification(
 }
 
 func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queue) {
+	start := time.Now()
 	deliveryChan := make(chan kafka.Event)
 	for _, event := range events {
 		msg, err := json.Marshal(event)
@@ -164,11 +165,15 @@ func produceMessages(p Producer, events []*eventqueue.Event, eq *eventqueue.Queu
 			}
 			logrus.Infof("Message produced: %v", message)
 		}
-		err = eq.MarkEventAsProcessed(event.ID)
-		if err != nil {
-			logrus.Fatalf("Error marking record as processed %v", err)
-		}
+		go func() {
+			err := eq.MarkEventAsProcessed(event.ID)
+			if err != nil {
+				logrus.Fatalf("Error marking record as processed %v", err)
+			}
+		}()
 	}
+	elapsed := time.Since(start)
+	fmt.Printf("productMessage / 1000 took %s", elapsed)
 }
 
 func setupProducer() Producer {


### PR DESCRIPTION
I implement a small improvement in the code. Try to using goroutine when marking a change as processed on DB and the result is:
productMessage / 100 took 17.970247726s --> without goroutine
productMessage / 100 took 14.196684991s --> with goroutine

productMessage / 1000 took 2m21.384167629s --> without goroutine
productMessage / 1000 took 2m6.867825506s --> with goroutine

Should we implement it? Or the difference is too small to consider as performance improvement? Also in this improvement the trade-off is we can't do anything when update to DB failed.